### PR TITLE
Fixed IndexError exception when station_name is not found

### DIFF
--- a/mvg_api/__init__.py
+++ b/mvg_api/__init__.py
@@ -99,7 +99,10 @@ def get_id_for_station(station_name):
     If more than one station match, the first result is given.
     `None` is returned if no match was found.
     """
-    station = get_stations(station_name)[0]
+    try:
+        station = get_stations(station_name)[0]
+    except IndexError:
+        return None
     return station['id']
 
 


### PR DESCRIPTION
If you call get_id_for_station(station_name) and the station_name is unknown, the method throws an exception instead of returning None. This issue is fixed here.