### PR TITLE
Add exact headers of a website request to API call

### DIFF
--- a/mvg_api/__init__.py
+++ b/mvg_api/__init__.py
@@ -15,7 +15,7 @@ interruptions_url = "https://www.mvg.de/.rest/betriebsaenderungen/api/interrupti
 
 
 def _perform_api_request(url):
-    resp = requests.get(url, headers={'X-MVG-Authorization-Key': api_key})
+    resp = requests.get(url, headers={'X-MVG-Authorization-Key': api_key, 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36', 'Accept': 'application/json, text/javascript, */*; q=0.01', 'Referer': 'https://www.mvg.de/dienste/abfahrtszeiten.html', 'Sec-Fetch-Mode': 'cors', 'X-Requested-With': 'XMLHttpRequest'})
     return resp.json()
 
 

--- a/mvg_api/__init__.py
+++ b/mvg_api/__init__.py
@@ -15,7 +15,7 @@ interruptions_url = "https://www.mvg.de/.rest/betriebsaenderungen/api/interrupti
 
 
 def _perform_api_request(url):
-    resp = requests.get(url, headers={'X-MVG-Authorization-Key': api_key, 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36', 'Accept': 'application/json, text/javascript, */*; q=0.01', 'Referer': 'https://www.mvg.de/dienste/abfahrtszeiten.html', 'Sec-Fetch-Mode': 'cors', 'X-Requested-With': 'XMLHttpRequest'})
+    resp = requests.get(url, headers={'X-MVG-Authorization-Key': api_key, 'User-Agent': 'python-mvg-api/1 (+https://github.com/leftshift/python_mvg_api)', 'Accept': 'application/json'})
     return resp.json()
 
 


### PR DESCRIPTION
Currently the API calls to MVG don't work as they banned the User-Agent.
This PR adds the exact same headers to the request as a current Chrome on macOS does to their API when using the website.
Closes #10 