### PR TITLE
fix urls

### DIFF
--- a/mvg_api/__init__.py
+++ b/mvg_api/__init__.py
@@ -6,11 +6,11 @@ import datetime
 from time import mktime
 
 api_key = "5af1beca494712ed38d313714d4caff6"
-query_url_name = "https://www.mvg.de/fahrinfo/api/location/queryWeb?q={name}" #for station names
-query_url_id = "https://www.mvg.de/fahrinfo/api/location/query?q={id}" #for station ids
-departure_url = "https://www.mvg.de/fahrinfo/api/departure/{id}?footway=0"
-nearby_url = "https://www.mvg.de/fahrinfo/api/location/nearby?latitude={lat}&longitude={lon}"
-routing_url = "https://www.mvg.de/fahrinfo/api/routing/?"
+query_url_name = "https://www.mvg.de/api/fahrinfo/location/queryWeb?q={name}" #for station names
+query_url_id = "https://www.mvg.de/api/fahrinfo/location/query?q={id}" #for station ids
+departure_url = "https://www.mvg.de/api/fahrinfo/departure/{id}?footway=0"
+nearby_url = "https://www.mvg.de/api/fahrinfo/location/nearby?latitude={lat}&longitude={lon}"
+routing_url = "https://www.mvg.de/api/fahrinfo/routing/?"
 interruptions_url = "https://www.mvg.de/.rest/betriebsaenderungen/api/interruptions"
 
 


### PR DESCRIPTION
Apparently the api urls changed…
The mvg website now uses `mvg.de/api/fahrinfo/…` instead of `mvg.de/fahrinfo/api/…`.
The old ones return 404 or 500 errors.